### PR TITLE
Add accuracy and averaging logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ config.ini
 __pycache__/
 output/
 gpx/
+.venv

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "heatmap.py with Arguments",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/heatmap.py",
+            "console": "integratedTerminal",
+            "args": [
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Options:
   --input TEXT                    Specify an input folder. Defaults to `gpx`
   --filter [running|cycling|walking]
                                   Specify a filter type. Defaults to no filter
+  --accuracy                      Number of decimal places to round lat/long to. Defaults to `4`
+                                  Increasing accuracy increases amount of data that needs to load
+  --average/--no-average          Averages all lat/long at accuracy N+1 to provide more accurate
+                                  data with less data points. Defaults to `--average`
   --help                          Show this message and exit.
 ```
 
@@ -52,3 +56,7 @@ $ python3 heatmap.py --input gpx --output map
 - Strava users can follow [Strava's instructions](https://support.strava.com/hc/en-us/articles/216918437-Exporting-your-Data-and-Bulk-Export) to export GPX data
 
 **Note:** [GPSBabel](https://www.gpsbabel.org/download.html) tool may help you convert from file formats such as `.tcx` to `.gpx` files
+
+#### Accuracy Levels
+
+See [this explanation](https://gis.stackexchange.com/a/8674/121567) for how decimals places correspond to map accuracy for lat/long.

--- a/heatmap.py
+++ b/heatmap.py
@@ -17,7 +17,7 @@ getcontext().prec = 12
 @click.option("--output", default="map", help="Specify the name of the output file. Defaults to `map`")
 @click.option("--input", default="gpx", help="Specify an input folder. Defaults to `gpx`")
 @click.option("--filter", default=None, help="Specify a filter type. Defaults to no filter", type=click.Choice(['running', 'cycling', 'walking']))
-@click.option("--accuracy", default=4, help="Decimals places of lat/long to use Defaults to `5`")
+@click.option("--accuracy", default=4, help="Decimals places of lat/long to use Defaults to `4`")
 @click.option("--average/--no-average", default=True, help="Average points below accuracy or use lat/long grouping?")
 def main(output, input, filter,accuracy,average):
     points = load_points(input, filter, accuracy, average)

--- a/heatmap.py
+++ b/heatmap.py
@@ -2,6 +2,8 @@ import gpxpy
 import click
 import os
 from configparser import ConfigParser
+from decimal import *
+import traceback
 
 parser = ConfigParser()
 parser.read('config.ini')
@@ -9,18 +11,27 @@ API_KEY = parser.get('GOOGLE', 'API_KEY')
 INITIAL_LATITUDE = parser.get('MAP', 'LATITUDE')
 INITIAL_LONGITUDE = parser.get('MAP', 'LONGITUDE')
 INITIAL_ZOOM = parser.get('MAP', 'ZOOM')
+getcontext().prec = 12
 
 @click.command()
 @click.option("--output", default="map", help="Specify the name of the output file. Defaults to `map`")
 @click.option("--input", default="gpx", help="Specify an input folder. Defaults to `gpx`")
 @click.option("--filter", default=None, help="Specify a filter type. Defaults to no filter", type=click.Choice(['running', 'cycling', 'walking']))
-def main(output, input, filter):
-    points = load_points(input, filter)
+@click.option("--accuracy", default=4, help="Decimals places of lat/long to use Defaults to `5`")
+@click.option("--average/--no-average", default=True, help="Average points below accuracy or use lat/long grouping?")
+def main(output, input, filter,accuracy,average):
+    points = load_points(input, filter, accuracy, average)
     generate_html(points, output)
 
-def load_points(folder, filter):
+def load_points(folder, filter,accuracy, average):
     """Loads all gpx files into a list of points"""
+    coordMap = {}
     coords = []
+
+    # https://gis.stackexchange.com/a/8674/121567
+    PLACES = Decimal(10) ** (-1 * accuracy)
+    UNDER_PLACES = Decimal(10) ** (-1 * accuracy)
+
     print (f"Loading files with type {filter}...") #Loads files with progressbar
     with click.progressbar(os.listdir(folder)) as bar:
         for filename in bar:
@@ -32,8 +43,40 @@ def load_points(folder, filter):
                     if not filter or filter==track.type:
                         for segment in track.segments:
                             for point in segment.points:
-                            	coords.append([float(point.latitude), float(point.longitude)])
+                                try:
+                                    lat = Decimal(point.latitude)
+                                    long = Decimal(point.longitude)
+                                    latgroup = lat.quantize(PLACES)
+                                    longgroup = long.quantize(PLACES)
+                                    k = ''.join([str(latgroup), str(longgroup)])
+                                    if k in coordMap:
+                                        coordMap[k]["count"] += 1
+                                        if average:
+                                            coordMap[k]["points"].append([lat,long])
+                                    else:
+                                        coordMap[k] = {"points": [], "count": 1}
+                                        if average:
+                                            coordMap[k]["points"].append([lat,long])
+                                        else:
+                                            coordMap[k]["points"].append([latgroup,longgroup])
+                                except Exception:
+                                    print("Failed coordinate load but continuning")
+                                    print(traceback.format_exc())
+                                #coords.append([Decimal(point.latitude).quantize(PLACES), Decimal(point.longitude).quantize(PLACES)])
 
+    for key,value in coordMap.items():
+        if average:
+            latTotal = Decimal(0)
+            longTotal = Decimal(0)
+            for lat,long in value["points"]:
+                latTotal = latTotal + lat
+                longTotal = longTotal + long
+            
+            latavg = Decimal(latTotal / len(value["points"])).quantize(UNDER_PLACES)
+            longavg = Decimal(longTotal / len(value["points"])).quantize(UNDER_PLACES)
+            coords.append([[latavg, longavg], value["count"]])
+        else:
+            coords.append([value["points"][0], value["count"]])
     return (coords)
 
 def get_outline():
@@ -48,7 +91,8 @@ def generate_html(points, file_out):
         os.mkdir('output')
     f = open(f"output/{file_out}.html", "w")
     outline = get_outline()
-    google_points = ",\n".join([f"new google.maps.LatLng({point[0]}, {point[1]})" for point in points])
+    #google_points = ",\n".join([f"new google.maps.LatLng({point[0]}, {point[1]})" for point in points])
+    google_points = ",\n".join([f"{{location: new google.maps.LatLng({point[0][0]}, {point[0][1]}), weight: {point[1]}}}" for point in points])
     updated_content = outline.replace("LIST_OF_POINTS", google_points).replace("API_KEY", API_KEY).replace("INIT_LATITUDE", INITIAL_LATITUDE).replace("INIT_LONGITUDE", INITIAL_LONGITUDE).replace("INIT_ZOOM", INITIAL_ZOOM)
     f.write(updated_content)
     f.close()


### PR DESCRIPTION
Enables user to control how many points are generated and at what accuracy

Adds to cli args:

* `--accuracy` - Number of decimal places to round/truncate lat/long at
  * [Decimal places accuracy conversion guide](https://gis.stackexchange.com/questions/8650/measuring-accuracy-of-latitude-and-longitude)
  * When parsing lat/long from GPX coordinates are grouped into buckets based on accuracy rounding, then google maps heatmap uses [Weighted Data Points](https://developers.google.com/maps/documentation/javascript/heatmaplayer#add_weighted_data_points) to represent multiple points at that accuracy rather than inserting all points
  * This reduces number of points on map which can greatly reduce data that needs to be loaded and increases map performance
  * Defaults to `4` decimal places = 11m of accuracy
* `--average/--no-average` - (Default `true`) When true the buckets of points at N accuracy are averaged to N+1 decimals.
  * This can give a more accurate lat/long for a bucket under most circumstances. 
  * When used this effectively makes N accuracy a "fenced" chunk of space where only one weighted point will be loaded. For EX road biking with `--accuracy 4 --average` would basically be "for each 11m square of road one `1.1m` accurate weighted point will be added.